### PR TITLE
custom projections, fixed sys.Lam0 and sys.Phi0

### DIFF
--- a/Convert.go
+++ b/Convert.go
@@ -77,6 +77,12 @@ func Inverse(src EPSGCode, input []float64) ([]float64, error) {
 	return conv.inverse(input)
 }
 
+// CustomProjection provides write-only access to the internal projection list
+// so that projections may be added without having to modify the library code.
+func CustomProjection(code EPSGCode, str string) {
+	projStrings[code] = str
+}
+
 //---------------------------------------------------------------------------
 
 // conversion holds the objects needed to perform a conversion

--- a/core/System.go
+++ b/core/System.go
@@ -441,13 +441,13 @@ func (sys *System) processMisc() error {
 	/* Central meridian */
 	f, ok := sys.ProjString.GetAsFloat("lon_0")
 	if ok {
-		sys.Lam0 = f
+		sys.Lam0 = f * support.DegToRad
 	}
 
 	/* Central latitude */
 	f, ok = sys.ProjString.GetAsFloat("lat_0")
 	if ok {
-		sys.Phi0 = f
+		sys.Phi0 = f * support.DegToRad
 	}
 
 	/* False easting and northing */

--- a/core/System.go
+++ b/core/System.go
@@ -139,6 +139,7 @@ func NewSystem(ps *support.ProjString) (*System, IOperation, error) {
 		Left:       IOUnitsAngular,
 		Right:      IOUnitsClassic,
 		Axis:       "enu",
+		FromMeter:  1.0,
 	}
 
 	err = sys.initialize()


### PR DESCRIPTION
Added CustomProjection() to Convert.go to allow custom projection strings to be loaded in without having to modify the package.

More importantly, while trying to use this package with EPSG3005, which uses the Albers Equal Area projection, it was discovered that numerous problems with that projection were being caused by sys.Lam0 and sys.Phi0 being in degrees, whereas anywhere those values are referenced in the code, they are referenced as radians.

Also changed default value of sys.FromMeter to 1.0, as the go zero value of 0.0 was causing divide by 0 errors when units were specified in the proj string.