### PR TITLE
Set ESPGCode type on coordinate system codes

### DIFF
--- a/Convert.go
+++ b/Convert.go
@@ -25,11 +25,11 @@ type EPSGCode int
 const (
 	EPSG3395                    EPSGCode = 3395
 	WorldMercator                        = EPSG3395
-	EPSG3857                             = 3857
+	EPSG3857                    EPSGCode = 3857
 	WebMercator                          = EPSG3857
-	EPSG4087                             = 4087
+	EPSG4087                    EPSGCode = 4087
 	WorldEquidistantCylindrical          = EPSG4087
-	EPSG4326                             = 4326
+	EPSG4326                    EPSGCode = 4326
 	WGS84                                = EPSG4326
 )
 


### PR DESCRIPTION
This sets the type on each of the coordinate system codes to align with the type set on `EPSG3395` and `WorldMercator` (by extension). Without a type definition, these consts are `int`s, being based off their value.